### PR TITLE
Add run directory controls to Level 2 runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Este repositório contém utilitários para executar o pipeline de validação n
 
 - `roger_hamilton/`: biblioteca com componentes reutilizáveis (geração de primos, construção do unitário, análise espectral e comparação com os zeros conhecidos).
 - `run_level2.py`: CLI que executa o pipeline completo, gera tabelas e gráficos (em SVG quando `matplotlib` não estiver disponível) e salva os logs exigidos pelos agentes.
-- `artifacts/`: diretório padrão para saídas (pode ser alterado via `--output-dir`).
+- `artifacts/`: diretório padrão para saídas (pode ser alterado via `--output-dir`). Cada execução é armazenada em uma subpasta própria (`run_YYYYMMDD-HHMMSS` por padrão).
 
 ## Requisitos
 
@@ -31,7 +31,8 @@ python run_level2.py \
   --P 700 --beta 1.0 --omega 1.05 \
   --seed 42 --m 30 \
   --spacing-count 200 \
-  --output-dir artifacts/reference
+  --output-dir artifacts/reference \
+  --run-name referencia
 ```
 
 Saídas esperadas:
@@ -41,6 +42,8 @@ Saídas esperadas:
 - `tables/level2_m30.csv`: tabela \((\gamma_n, E_n, \Delta_n)\).
 - `plots/hist_spacing.svg`, `plots/ecdf_spacing.svg`, `plots/delta_vs_n.svg`: gráficos de apoio.
 
+> **Nota:** omitir `--run-name` cria automaticamente uma pasta com timestamp (`run_20240101-120000`, por exemplo). Use `--reset-output` para limpar completamente o diretório indicado em `--output-dir` antes de uma nova bateria de testes.
+
 > **Nota:** o script aborta automaticamente caso \(\lVert U^\* U - I \rVert_2 > 10^{-10}\), conforme solicitado pelos agentes.
 
 ## Desenvolvimento
@@ -48,7 +51,7 @@ Saídas esperadas:
 Para executar um teste rápido com uma malha menor:
 
 ```bash
-python run_level2.py --N 128 --T 8 --P 100 --m 10 --spacing-count 50 --output-dir artifacts/smoke
+python run_level2.py --N 128 --T 8 --P 100 --m 10 --spacing-count 50 --output-dir artifacts/smoke --run-name teste
 ```
 
 Isso gera as mesmas saídas em resolução reduzida, útil para validar o ambiente antes de uma varredura completa.

--- a/run_level2.py
+++ b/run_level2.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import datetime
 import json
-import math
+import shutil
 from pathlib import Path
 from typing import Callable, Iterable, Literal, Sequence
 
@@ -89,7 +90,36 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--spacing-count", type=int, default=200, help="Number of eigenvalues used for spacing stats")
     parser.add_argument("--eigen-mode", choices=["log", "cayley"], default="log")
     parser.add_argument("--output-dir", type=Path, default=Path("artifacts"))
+    parser.add_argument(
+        "--run-name",
+        type=str,
+        default=None,
+        help=(
+            "Name of the subdirectory used for this run. When omitted a timestamped"
+            " folder is created."
+        ),
+    )
+    parser.add_argument(
+        "--reset-output",
+        action="store_true",
+        help="Remove the entire output directory before writing new results.",
+    )
     return parser.parse_args()
+
+
+def _prepare_run_directory(base_dir: Path, run_name: str | None, reset: bool) -> Path:
+    if reset and base_dir.exists():
+        shutil.rmtree(base_dir)
+
+    base_dir.mkdir(parents=True, exist_ok=True)
+
+    if run_name is None:
+        timestamp = datetime.datetime.now(tz=datetime.timezone.utc).strftime("%Y%m%d-%H%M%S")
+        run_name = f"run_{timestamp}"
+
+    run_dir = base_dir / run_name
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir
 
 
 def _ensure_unitarity(U: np.ndarray) -> float:
@@ -233,7 +263,7 @@ def _plot_delta_vs_n(delta: np.ndarray, output: Path) -> None:
 
 def main() -> None:
     args = _parse_args()
-    output_dir = args.output_dir
+    run_dir = _prepare_run_directory(args.output_dir, args.run_name, args.reset_output)
 
     params = {
         "mode": args.mode,
@@ -248,6 +278,10 @@ def main() -> None:
         "m": args.m,
         "spacing_count": args.spacing_count,
         "eigen_mode": args.eigen_mode,
+        "output_root": str(args.output_dir),
+        "run_directory": str(run_dir),
+        "run_name": run_dir.name,
+        "reset_output": args.reset_output,
     }
 
     unitary = construct_unitary(
@@ -262,24 +296,25 @@ def main() -> None:
     )
 
     norm = _ensure_unitarity(unitary.matrix)
-    save_unitarity_report(output_dir / "logs" / "unitarity_check.txt", norm)
-    save_params(output_dir / "logs" / "params.json", params)
+    save_unitarity_report(run_dir / "logs" / "unitarity_check.txt", norm)
+    save_params(run_dir / "logs" / "params.json", params)
 
     spectrum = eigenvalues_from_unitary(unitary.matrix, mode=args.eigen_mode)
     comparison = compare_spectrum(spectrum.eigenvalues, args.m)
-    save_level2_table(comparison, output_dir / "tables" / f"level2_m{comparison.m}.csv")
+    save_level2_table(comparison, run_dir / "tables" / f"level2_m{comparison.m}.csv")
 
     spacing_stats = spacing_statistics(spectrum.eigenvalues, args.spacing_count)
 
-    _plot_spacing_histogram(spacing_stats.normalised_gaps, output_dir / "plots" / "hist_spacing.svg")
-    _plot_spacing_ecdf(spacing_stats.normalised_gaps, output_dir / "plots" / "ecdf_spacing.svg")
-    _plot_delta_vs_n(comparison.delta, output_dir / "plots" / "delta_vs_n.svg")
+    _plot_spacing_histogram(spacing_stats.normalised_gaps, run_dir / "plots" / "hist_spacing.svg")
+    _plot_spacing_ecdf(spacing_stats.normalised_gaps, run_dir / "plots" / "ecdf_spacing.svg")
+    _plot_delta_vs_n(comparison.delta, run_dir / "plots" / "delta_vs_n.svg")
 
     summary = {
         "rmse": comparison.rmse,
         "max_abs_error": comparison.max_abs_error,
         "ks_statistic": spacing_stats.ks_statistic,
         "mean_gap_ratio": spacing_stats.mean_gap_ratio,
+        "output_directory": str(run_dir),
     }
     print(json.dumps(summary, indent=2))
 


### PR DESCRIPTION
## Summary
- add CLI options to reset the output directory and to name per-run subfolders in `run_level2.py`
- automatically create timestamped run directories and persist run metadata paths in saved params
- document the new workflow and options for isolating logs per execution in the README

## Testing
- `python -m compileall run_level2.py roger_hamilton`


------
https://chatgpt.com/codex/tasks/task_e_68e3b6ef16fc8330a3d44dfeb272a83f